### PR TITLE
dir-seq function

### DIFF
--- a/src/fs/core.clj
+++ b/src/fs/core.clj
@@ -265,6 +265,15 @@
   [func path]
   (map #(apply func %) (iterate-dir path)))
 
+(defn dir-seq
+  "Return a flattened sequence of all the files within (and including)
+  the directory pointed by path. Operates recursively. If path is
+  pointing to a file, the file itself is returned in a sequence."
+  [path]
+  (tree-seq #(directory? %)
+            #(map file (.listFiles %))
+            (file path)))
+
 (defn touch
   "Set file modification time (default to now). Returns path."
   [path & time]


### PR DESCRIPTION
Hello,

I have implemented dir-seq which returns a flattened directory structure as a seq. In terms of what it does, it's similar to iterate-dir, but I think it would be useful to have a more simple version in order to allow easy mapping, filtering, removing etc on the returned sequence. :-)
