### PR TITLE
Added support for ~user/foo/bar style with a tilde and explicit username

### DIFF
--- a/src/fs/core.clj
+++ b/src/fs/core.clj
@@ -20,15 +20,22 @@
              in this library."}
   cwd (atom (.getCanonicalFile (io/file "."))))
 
+(let [homedir (io/file (System/getProperty "user.home"))
+      usersdir (.getParent homedir)]
 (defn home
   "User home directory"
-  [] (System/getProperty "user.home"))
+  ([] homedir)
+  ([user] (if (empty? user) homedir (io/file usersdir user)))))
 
 (defn- expand-path [path]
   (let [path (str path)]
     (cond
      (= path ".") @cwd
-     (.startsWith path "~") (str (home) (subs path 1))
+     (.startsWith path "~") 
+     (let [sep (.indexOf path File/separator)]
+       (if (neg? sep)
+         (home (subs path 1))
+         (io/file (home (subs path 1 sep)) (subs path (inc sep)))))
      :else path)))
 
 ;; Library functions will call this function on paths/files so that

--- a/test/fs/core_test.clj
+++ b/test/fs/core_test.clj
@@ -184,7 +184,20 @@
 
 (when (System/getenv "HOME")
   (fact
-    (home) => (System/getenv "HOME")))
+   (let [env-home (io/file (System/getenv "HOME"))]
+     (home) => env-home
+     (home "") => env-home
+     (home (System/getProperty "user.name")) => env-home
+     (file "~") => env-home
+     (file "~/") => env-home
+     (file "~foo/bar.txt") => (file (parent env-home) "foo" "bar.txt"))))
+
+
+(fact
+ (let [username (System/getProperty "user.name")
+       foo (io/file (System/getProperty "user.home") "foo.bar")]
+   (file "~/foo.bar") => foo
+   (file (str "~" username) "foo.bar") => foo))
 
 (tabular
   (fact (split-ext ?file) => ?ext)


### PR DESCRIPTION
For unix systems, it's common to write ~user for the user's home directory.  Java doesn't have a standard way to do this, but the usual practice is for all user home directories to be in the same parent directory, such as /Users/ on Mac OS X.  The most important case is that the current user should work with ~user meaning the same thing as plain ~.

Also, changed (home) to return a File rather than a string.  That seems more consistent with the rest of the library.

The patch was tested only on Mac OS X.
