### PR TITLE
the extension should include the period

### DIFF
--- a/src/fs/core.clj
+++ b/src/fs/core.clj
@@ -120,13 +120,12 @@
   (.isFile (file path)))
 
 (defn split-ext
-  "Returns a vector of [filename extension]"
+  "Returns a vector of [name extension]."
   [path]
   (let [base (base-name path)
         i (.lastIndexOf base ".")]
     (if (pos? i)
-      (let [[name ext] (split-at i base)]
-        [(string/join name) (-> ext rest string/join)])
+      [(subs base 0 i) (subs base i)]
       [base nil])))
 
 (defn extension
@@ -166,7 +165,6 @@
 
 (def unix-root "The root of a unix system is /, nil on Windows"
   (when (= File/separator "/") File/separator))
-
 
 (defn split
   "Split path to components."

--- a/test/fs/core_test.clj
+++ b/test/fs/core_test.clj
@@ -208,21 +208,23 @@
   (fact (split-ext ?file) => ?ext)
   
     ?file            ?ext
-    "fs.clj"        ["fs" "clj"]
-    "fs."           ["fs" ""]
-    "fs.clj.bak"    ["fs.clj" "bak"]
+    "fs.clj"        ["fs" ".clj"]
+    "fs."           ["fs" "."]
+    "fs.clj.bak"    ["fs.clj" ".bak"]
     "/path/to/fs"   ["fs" nil]
-    ""              ["fs" nil])
+    ""              ["fs" nil]
+    "~user/.bashrc" [".bashrc" nil])
 
 (tabular
   (fact (extension ?file) => ?ext)
   
     ?file            ?ext
-    "fs.clj"        "clj"
-    "fs."           ""
-    "fs.clj.bak"    "bak"
+    "fs.clj"        ".clj"
+    "fs."           "."
+    "fs.clj.bak"    ".bak"
     "/path/to/fs"   nil
-    ""              nil)
+    ""              nil
+    ".bashrc"       nil)
 
 (tabular
   (fact (name ?file) => ?ext)
@@ -232,7 +234,8 @@
     "fs."           "fs"
     "fs.clj.bak"    "fs.clj"
     "/path/to/fs"   "fs"
-    ""              "fs")
+    ""              "fs"
+    ".bashrc"       ".bashrc")
 
 (fact
   (let [old @cwd]


### PR DESCRIPTION
In the released fs 1.0.0, `extension` includes the period.  Python's os.path.splitext does too.  My tests showed that using subs was a bit faster than the splitting the characters and rejoining them.  I think it's easier to read as well.  I added some tests, including one for the special case of a filename beginning with a "." -- the whole thing should be considered the name, with no extension.
