### PR TITLE
add optional arg to base-name to trim-ext, like unix basename

### DIFF
--- a/src/fs/core.clj
+++ b/src/fs/core.clj
@@ -105,9 +105,18 @@
   (.getCanonicalFile (file path)))
 
 (defn base-name
-  "Return the base name (final segment/file part) of a path."
-  [path]
-  (.getName (file path)))
+  "Return the base name (final segment/file part) of a path.
+If optional 'trim-ext' is a string and the path ends with that string, it is trimmed.
+If 'trim-ext' is true, any extension is trimmed."
+  ([path] (.getName (file path)))
+  ([path trim-ext] 
+     (let [base (.getName (file path))]
+       (cond (string? trim-ext) (if (.endsWith base trim-ext)
+                                  (subs base 0 (- (.length base) (.length trim-ext)))
+                                  base)
+             trim-ext (let [dot (.lastIndexOf base ".")]
+                        (if (pos? dot) (subs base 0 dot) base))
+             :else base))))
 
 (defn directory?
   "Return true if path is a directory."

--- a/test/fs/core_test.clj
+++ b/test/fs/core_test.clj
@@ -94,7 +94,10 @@
   (normalized-path ".") => @cwd)
 
 (fact
-  (base-name "foo/bar") => "bar")
+  (base-name "foo/bar") => "bar"
+  (base-name "foo/bar.txt" true) => "bar"
+  (base-name "bar.txt" ".txt") => "bar"
+  (base-name "foo/bar.txt" ".png") => "bar.txt")
 
 (fact
   (let [tmp (temp-file)]


### PR DESCRIPTION
I often need to make a new file with the same root, but a different extension.  This patch overlaps somewhat with the new `name` function.  However, trim-ext can also be used to trim only a particular extension.  The functionality is similar to the unix basename.
