### PR TITLE
Improve delete-dir

### DIFF
--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -432,7 +432,7 @@
   "Delete a directory tree."
   [root]
   (when (directory? root)
-    (doseq [path (map #(file root %) (.list (file root)))]
+    (doseq [path (.listFiles (file root))]
       (delete-dir path)))
   (delete root))
 


### PR DESCRIPTION
Silly to ask for strings and then convert to files, rather than just asking for files.
