### PR TITLE
Delete dir link support

### DIFF
--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -139,6 +139,14 @@
   [path]
   (.isHidden (file path)))
 
+(defn delete-dir
+  "Delete a directory tree."
+  [root]
+  (when (directory? root)
+    (doseq [path (.listFiles (file root))]
+      (delete-dir path)))
+  (delete root))
+
 (defmacro ^:private include-java-7-fns []
   (when (try (import '[java.nio.file Files Path LinkOption]
                      '[java.nio.file.attribute FileAttribute])
@@ -177,14 +185,23 @@
                (as-path target)
                (make-array FileAttribute 0))))
 
-      ;; Rewrite directory? to include LinkOptions.
+      ;; Rewrite directory? and delete-dir to include LinkOptions.
       (defn directory?
         "Return true if path is a directory, false otherwise.  Optional
        LinkOptions may be provided to determine whether or not to follow
        symbolic links."
         [path & link-options]
         (Files/isDirectory (as-path path)
-                           (into-array LinkOption link-options))))))
+                           (into-array LinkOption link-options)))
+
+      (defn delete-dir
+        "Delete a directory tree.  Optional LinkOptions may be provided to
+       determine whether or not to follow symbolic links."
+        [root & link-options]
+        (when (apply directory? root link-options)
+          (doseq [path (.listFiles (file root))]
+            (apply delete-dir path link-options)))
+        (delete root)))))
 
 (include-java-7-fns)
 
@@ -436,14 +453,6 @@
                    (copy+ (file root f) (dest (file root f)))))
                from))
         to))))
-
-(defn delete-dir
-  "Delete a directory tree."
-  [root]
-  (when (directory? root)
-    (doseq [path (.listFiles (file root))]
-      (delete-dir path)))
-  (delete root))
 
 (defn parents
   "Get all the parent directories of a path."

--- a/test/me/raynes/core_test.clj
+++ b/test/me/raynes/core_test.clj
@@ -359,6 +359,17 @@
           (file? soft) => false
           (directory? soft) => true
           (directory? soft LinkOption/NOFOLLOW_LINKS) => false
-          (delete soft))))))
+          (delete soft)))
+
+       (fact
+        (let [root (create-walk-dir)
+              soft-a (sym-link (io/file root "soft-a.link") (io/file root "a"))
+              soft-b (sym-link (io/file root "soft-b.link") (io/file root "b"))]
+          (delete-dir soft-a LinkOption/NOFOLLOW_LINKS)
+          (exists? (io/file root "a" "2")) => true
+          (delete-dir soft-b)
+          (exists? (io/file root "b" "3")) => false
+          (delete-dir root)
+          (exists? root) => false)))))
 
 (run-java-7-tests)


### PR DESCRIPTION
Adds support for LinkOptions to `directory?` and `delete-dir` on Java 7.

The resulting usage looks like:

``` clojure
;; As before:
(delete-dir root)

;; If you do not want to follow symbolic links
;; This deletes the link only, not the contents of its target directory
(delete-dir root LinkOption/NOFOLLOW_LINKS)
```
