### PR TITLE
Added a comment clarifying the link call in its docstring.

### DIFF
--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -169,9 +169,11 @@
 
       (defn ^File link
         "Create a \"hard\" link from path to target.
-       Requires Java version 7 or greater."
-        [path target]
-        (file (Files/createLink (as-path path) (as-path target))))
+       Requires Java version 7 or greater.  The arguments
+       are in the opposite order from the link(2) system
+       call."
+        [new-file existing-file]
+        (file (Files/createLink (as-path new-file) (as-path existing-file))))
 
       (defn ^File sym-link
         "Create a \"soft\" link from path to target.


### PR DESCRIPTION
On unix systems, the link() system call uses the convention

 link(const char *oldpath, const char *newpath)

However in java7 (when createLink was added), the createLink call asks
the programmer to use the arguments in the opposite order:

 createLink(newpath, oldpath)

fs/link goes with the java convention, even though the name shadows
the system call's name.  This commit is adding info to the docstring
clarifying which file needs to exist and which one will be created.
It also re-names the arguments to make clear which one must already
exist, and which one is being created.