### PR TITLE
Fix temp-create to try different names each time

### DIFF
--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -284,8 +284,8 @@
 (defn- temp-create
   "Create a temporary file or dir, trying n times before giving up."
   ([prefix suffix tries f]
-   (let [tmp (file (tmpdir) (temp-name prefix suffix))]
-     (loop [tries tries]
+   (loop [tries tries]
+     (let [tmp (file (tmpdir) (temp-name prefix suffix))]
        (when (pos? tries)
          (if (f tmp)
            tmp


### PR DESCRIPTION
The bugfix in commit d299122 had a bug itself: if a temp name conflicted with an already-existing filename, it would have tried the same temp name over and over.
