### PR TITLE
Change 'expand-home' to support Unix style paths on windows.

### DIFF
--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -37,7 +37,7 @@
    This is (naively) assumed to be a directory with the same name as the
    user relative to the parent of the current value of user.home."
   [path]
-  (let [path (str path)]
+  (let [path (str (io/as-file path))]
     (if (.startsWith path "~")
       (let [sep (.indexOf path File/separator)]
         (if (neg? sep)

--- a/test/me/raynes/core_test.clj
+++ b/test/me/raynes/core_test.clj
@@ -8,7 +8,6 @@
   (:import java.io.File))
 
 (def system-tempdir (System/getProperty "java.io.tmpdir"))
-(def on-windows? (= File/separator "\\"))
 
 (defn create-walk-dir []
   (let [root (temp-dir "fs-")]

--- a/test/me/raynes/core_test.clj
+++ b/test/me/raynes/core_test.clj
@@ -8,6 +8,7 @@
   (:import java.io.File))
 
 (def system-tempdir (System/getProperty "java.io.tmpdir"))
+(def on-windows? (= File/separator "\\"))
 
 (defn create-walk-dir []
   (let [root (temp-dir "fs-")]
@@ -25,6 +26,7 @@
 (fact "Expands path to current user."
   (let [user (System/getProperty "user.home")]
     (expand-home "~") => (file user)
+    (expand-home "~/foo") => (file user "foo")
     (expand-home (str "~" File/separator "foo")) => (file user "foo")))
 
 (fact "Expands to given user."


### PR DESCRIPTION
expand-home does not add the home to the path when on windows and the path string uses unix style path separators (which is generally OK in Java). Fix seems to be just ensure the path passed in is converted to a File object first which will convert the unix style separators to File/separator. 
