### PR TITLE
commons-compress 1.4 -> 1.8

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,6 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :url "https://github.com/Raynes/fs"
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.apache.commons/commons-compress "1.4"]]
+                 [org.apache.commons/commons-compress "1.8"]]
   :plugins [[lein-midje "3.0-alpha4"]]
   :profiles {:dev {:dependencies [[midje "1.5-alpha8"]]}})


### PR DESCRIPTION
There aren't any tests for this library, so I'm not sure how to figure out if this change is safe. Suggestions?
