### PR TITLE
Return a string rather than a file from parent.

### DIFF
--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -236,7 +236,7 @@
 (defn parent
   "Return the parent path."
   [path]
-  (.getParentFile (file path)))
+  (.getParent (file path)))
 
 (defn mod-time
   "Return file modification time."


### PR DESCRIPTION
The parent method was returning a file object rather than a string path, which meant to get the directory of a file you had to do something like (.getPath (parent "path/to/my/file.txt")).
