### PR TITLE
Add source links to the API documentation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [org.apache.commons/commons-compress "1.8"]]
   :plugins [[lein-midje "3.1.3"]
-            [codox "0.6.7"]]
+            [codox "0.8.10"]]
   :codox {:src-dir-uri "https://github.com/Raynes/fs/blob/master/"
           :src-linenum-anchor-prefix "L"}
   :deploy-repositories {"releases" :clojars}


### PR DESCRIPTION
When looking at the API documentation I find it useful to look at the source code sometimes. Codox can generate links to the source code if you tell it the link to the source code repo. This change does just that.
