### PR TITLE
Add functionality to query the content type of a path

### DIFF
--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -212,7 +212,12 @@
         (when (apply directory? root link-options)
           (doseq [path (.listFiles (file root))]
             (apply delete-dir path link-options)))
-        (delete root)))))
+        (delete root))
+
+      (defn content-type
+        "Return the content type of `path`."
+        [path]
+        (Files/probeContentType (as-path path))))))
 
 (include-java-7-fns)
 

--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -215,7 +215,9 @@
         (delete root))
 
       (defn content-type
-        "Return the content type of `path`."
+        "Return the content type of `path`. See the
+        [javadocs](http://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html#probeContentType%28java.nio.file.Path%29)
+        for more information.  Requires Java version 7 or greater."
         [path]
         (Files/probeContentType (as-path path))))))
 

--- a/test/me/raynes/core_test.clj
+++ b/test/me/raynes/core_test.clj
@@ -382,6 +382,16 @@
           (delete-dir soft-b)
           (exists? (io/file root "b" "3")) => false
           (delete-dir root)
-          (exists? root) => false)))))
+          (exists? root) => false))
+
+       (fact "Content type"
+        (let [tar (io/file test-files-path "ggg.tar")
+              zip (io/file test-files-path "ggg.zip")
+              xz (io/file test-files-path "xxx.xz")
+              txt (io/file test-files-path "foo.txt")]
+          (content-type tar) => "application/x-tar"
+          (content-type zip) => "application/zip"
+          (content-type xz) => "application/x-xz"
+          (content-type txt) => "text/plain")))))
 
 (run-java-7-tests)

--- a/test/me/raynes/testfiles/foo.txt
+++ b/test/me/raynes/testfiles/foo.txt
@@ -1,0 +1,1 @@
+This is a test file


### PR DESCRIPTION
using probeContentType from java.nio.file.Files

Seems fairly natural to add this functionality. 

Tests are added and they pass