### PR TITLE
expand-home should be consistent in what it returns

### DIFF
--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -44,7 +44,7 @@
         (if (neg? sep)
           (home (subs path 1))
           (io/file (home (subs path 1 sep)) (subs path (inc sep)))))
-      path)))
+      (io/file path))))
 
 ;; Library functions will call this function on paths/files so that
 ;; we get the cwd effect on them.

--- a/test/me/raynes/core_test.clj
+++ b/test/me/raynes/core_test.clj
@@ -33,8 +33,9 @@
     (expand-home (str "~" name)) => (file user)
     (expand-home (format "~%s/foo" name)) => (file user "foo")))
 
-(fact "Expand plain path just returns path"
-      (expand-home (str "melon" File/separator "peach")) => (io/file "melon" "peach"))
+(fact "Expand a path w/o tilde just returns path"
+      (let [user (System/getProperty "user.home")]
+        (expand-home (str user File/separator "foo")) => (io/file user "foo")))
 
 (fact (list-dir ".") => (has every? #(instance? File %)))
 

--- a/test/me/raynes/core_test.clj
+++ b/test/me/raynes/core_test.clj
@@ -33,6 +33,9 @@
     (expand-home (str "~" name)) => (file user)
     (expand-home (format "~%s/foo" name)) => (file user "foo")))
 
+(fact "Expand plain path just returns path"
+      (expand-home (str "melon" File/separator "peach")) => (io/file "melon" "peach"))
+
 (fact (list-dir ".") => (has every? #(instance? File %)))
 
 ;; Want to change these files to be tempfiles at some point.


### PR DESCRIPTION
Usually if you pass it a path string that starts with `~` it returns a
file. However if the path string does not start with `~` it simply
returns the string. This change makes the return value consistent:
always a file.