### PR TITLE
Files to be zipped passed as list of file paths

### DIFF
--- a/src/me/raynes/fs/compression.clj
+++ b/src/me/raynes/fs/compression.clj
@@ -65,6 +65,24 @@
   (io/copy (make-zip-stream filename-content-pairs)
            (fs/file filename)))
 
+(defn- slurp-bytes [fpath]
+  (with-open [data (io/input-stream fpath)]
+    (with-open [out (ByteArrayOutputStream.)]
+      (io/copy data out)
+      (.toByteArray out))))
+
+(defn zip-files
+  "Zip files provided in argument vector to a single zip. Converts the argument list:
+
+  ```(fpath1 fpath2...)```
+
+  into filename-content -pairs, using the original file's basename as the filename in zip`and slurping the content:
+
+  ```([fpath1-basename fpath1-content] [fpath2-basename fpath2-content]...)``"
+  [filename & fpaths]
+  (let [filename-content-pairs (map (juxt fs/base-name slurp-bytes) fpaths)]
+    (fsc/zip filename filename-content-pairs)))
+
 (defn- tar-entries
   "Get a lazy-seq of entries in a tarfile."
   [^TarArchiveInputStream tin]

--- a/src/me/raynes/fs/compression.clj
+++ b/src/me/raynes/fs/compression.clj
@@ -6,7 +6,8 @@
            (org.apache.commons.compress.archivers.tar TarArchiveInputStream
                                                       TarArchiveEntry)
            (org.apache.commons.compress.compressors bzip2.BZip2CompressorInputStream
-                                                    xz.XZCompressorInputStream)))
+                                                    xz.XZCompressorInputStream)
+           (java.io ByteArrayOutputStream)))
 
 (defn unzip
   "Takes the path to a zipfile `source` and unzips it to target-dir."
@@ -66,7 +67,7 @@
            (fs/file filename)))
 
 (defn- slurp-bytes [fpath]
-  (with-open [data (io/input-stream fpath)]
+  (with-open [data (io/input-stream (fs/file fpath))]
     (with-open [out (ByteArrayOutputStream.)]
       (io/copy data out)
       (.toByteArray out))))
@@ -81,7 +82,7 @@
   ```([fpath1-basename fpath1-content] [fpath2-basename fpath2-content]...)``"
   [filename & fpaths]
   (let [filename-content-pairs (map (juxt fs/base-name slurp-bytes) fpaths)]
-    (fsc/zip filename filename-content-pairs)))
+    (zip filename filename-content-pairs)))
 
 (defn- tar-entries
   "Get a lazy-seq of entries in a tarfile."

--- a/test/me/raynes/core_test.clj
+++ b/test/me/raynes/core_test.clj
@@ -287,14 +287,14 @@
     (slurp (file "round/some.txt")) => "some text")
 
   (fact "zip-files"
-    (zip-files "foobar.zip" "foo" "bar")
+    (zip-files "foobar.zip" ["foo" "bar"])
     (exists? "foobar.zip")
     (unzip "foobar.zip" "foobar")
     (exists? "foobar/foo") => true
     (exists? "foobar/bar") => true
     (delete "foobar.zip")
     (delete-dir "foobar"))
-  
+
   (fact
     (untar "ggg.tar" "zggg")
     (exists? "zggg/ggg") => true

--- a/test/me/raynes/core_test.clj
+++ b/test/me/raynes/core_test.clj
@@ -275,17 +275,26 @@
     (delete-dir "zggg"))
 
   (fact (zip "fro.zip" ["bbb.txt" "bbb"])
-        (exists? "fro.zip") => true
-        (unzip "fro.zip" "fro")
-        (exists? "fro/bbb.txt") => true
-        (delete "fro.zip")
-        (delete-dir "fro"))
+    (exists? "fro.zip") => true
+    (unzip "fro.zip" "fro")
+    (exists? "fro/bbb.txt") => true
+    (delete "fro.zip")
+    (delete-dir "fro"))
 
   (fact "about zip round trip"
     (zip "round.zip" ["some.txt" "some text"])
     (unzip "round.zip" "round")
     (slurp (file "round/some.txt")) => "some text")
 
+  (fact "zip-files"
+    (zip-files "foobar.zip" "foo" "bar")
+    (exists? "foobar.zip")
+    (unzip "foobar.zip" "foobar")
+    (exists? "foobar/foo") => true
+    (exists? "foobar/bar") => true
+    (delete "foobar.zip")
+    (delete-dir "foobar"))
+  
   (fact
     (untar "ggg.tar" "zggg")
     (exists? "zggg/ggg") => true


### PR DESCRIPTION
I had a use case where there's a list of local file paths that I need to zip. I added ```zip-files``` and ```make-zip-stream-from-files``` methods to do just that. They take a list of file paths, use the base name of each file as file name in zip and binary-slurp the data in, then pass all that to the original zip-stream method.