### PR TITLE
Fix zip file locking issue on Windows

### DIFF
--- a/src/me/raynes/fs/compression.clj
+++ b/src/me/raynes/fs/compression.clj
@@ -13,13 +13,13 @@
   ([source]
      (unzip source (name source)))
   ([source target-dir]
-     (let [zip (ZipFile. (fs/file source))
-           entries (enumeration-seq (.entries zip))
-           target-file #(fs/file target-dir (str %))]
-       (doseq [entry entries :when (not (.isDirectory ^java.util.zip.ZipEntry entry))
-               :let [f (target-file entry)]]
-         (fs/mkdirs (fs/parent f))
-         (io/copy (.getInputStream zip entry) f)))
+     (with-open [zip (ZipFile. (fs/file source))]
+       (let [entries (enumeration-seq (.entries zip))
+             target-file #(fs/file target-dir (str %))]
+         (doseq [entry entries :when (not (.isDirectory ^java.util.zip.ZipEntry entry))
+                 :let [f (target-file entry)]]
+           (fs/mkdirs (fs/parent f))
+           (io/copy (.getInputStream zip entry) f))))
      target-dir))
 
 (defn- add-zip-entry

--- a/test/me/raynes/core_test.clj
+++ b/test/me/raynes/core_test.clj
@@ -278,7 +278,8 @@
         (exists? "fro.zip") => true
         (unzip "fro.zip" "fro")
         (exists? "fro/bbb.txt") => true
-        (delete "fro.zip")
+        (rename "fro.zip" "fro2.zip") => true
+        (delete "fro2.zip")
         (delete-dir "fro"))
 
   (fact "about zip round trip"


### PR DESCRIPTION
If ZipFile is not closed, the file remains locked on Windows and can't be renamed or deleted. Tested on Windows 7. It seems that Linux and OS X are not affected.

I added a test that tries to rename a zip file after unzipping it. The test fails on Windows unless the ZipFile is closed. The patch uses `with-open` to close the file.