### PR TITLE
fix home function to actually query OS for users home directory

### DIFF
--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -19,15 +19,30 @@
        :dynamic true}
   *cwd* (.getCanonicalFile (io/file ".")))
 
+(def ^{:doc "Regular expression to match illegal characters in a username.
+             Used to prevent shell exploits, as bash is used to get users
+             home directory"}
+  invalid-username-regexp #"[^A-Za-z0-9\-\._]+")
+
 (let [homedir (io/file (System/getProperty "user.home"))
       usersdir (.getParent homedir)]
   (defn home
-    "With no arguments, returns the current value of the `user.home` system
-     property. If a `user` is passed, returns that user's home directory. It
-     is naively assumed to be a directory with the same name as the `user`
-     located relative to the parent of the current value of `user.home`."
-    ([] homedir)
-    ([user] (if (empty? user) homedir (io/file usersdir user)))))
+    "With no arguments, returns the current value of the `user.home`
+  system property. If a `user` is passed, returns that user's home
+  directory.  If user is not present on the system, returns nil. If
+  shell call fails (it will on windows), returns nil."
+    ([] (-> "user.home" System/getProperty io/file))
+    ([username]
+     (when-not
+         (re-find invalid-username-regexp username)
+       (let [{:keys [out exit]}
+             (->> username
+                  (str "echo ~")
+                  (sh/sh "sh" "-c"))]
+         (when (and
+                (zero? exit)
+                (not= "~" (subs out 0 1)))
+           (-> out string/trim io/file)))))))
 
 (defn expand-home
   "If `path` begins with a tilde (`~`), expand the tilde to the value

--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -24,25 +24,23 @@
              home directory"}
   invalid-username-regexp #"[^A-Za-z0-9\-\._]+")
 
-(let [homedir (io/file (System/getProperty "user.home"))
-      usersdir (.getParent homedir)]
-  (defn home
-    "With no arguments, returns the current value of the `user.home`
+(defn home
+  "With no arguments, returns the current value of the `user.home`
   system property. If a `user` is passed, returns that user's home
   directory.  If user is not present on the system, returns nil. If
   shell call fails (it will on windows), returns nil."
-    ([] (-> "user.home" System/getProperty io/file))
-    ([username]
-     (when-not
-         (re-find invalid-username-regexp username)
-       (let [{:keys [out exit]}
-             (->> username
-                  (str "echo ~")
-                  (sh/sh "sh" "-c"))]
-         (when (and
-                (zero? exit)
-                (not= "~" (subs out 0 1)))
-           (-> out string/trim io/file)))))))
+  ([] (-> "user.home" System/getProperty io/file))
+  ([username]
+   (when-not
+       (re-find invalid-username-regexp username)
+     (let [{:keys [out exit]}
+           (->> username
+                (str "echo ~")
+                (sh/sh "sh" "-c"))]
+       (when (and
+              (zero? exit)
+              (not= "~" (subs out 0 1)))
+         (-> out string/trim io/file))))))
 
 (defn expand-home
   "If `path` begins with a tilde (`~`), expand the tilde to the value


### PR DESCRIPTION
This resolves issue #12. I haven't tested it on windows, but on windows it will return nil, which is not ideal, but it never actually worked properly anyway, so it might be better.

``` bash
$ lein midje
All checks (108) succeeded.
```

``` clojure
me.raynes.fs> (home "crispin")
#object[java.io.File 0x15eda628 "/home/crispin"]
me.raynes.fs> (home "www-data")
#object[java.io.File 0x620327b6 "/var/www"]
me.raynes.fs> (home "root")
#object[java.io.File 0x7358d81 "/root"]
me.raynes.fs> (home "missing-user")
nil
me.raynes.fs> (home "root;echo wat")
nil
```
