### PR TITLE
Maintain file permissions in untar, and support octal chmod format

### DIFF
--- a/src/me/raynes/fs/compression.clj
+++ b/src/me/raynes/fs/compression.clj
@@ -79,7 +79,11 @@
        (doseq [^TarArchiveEntry entry (tar-entries tin) :when (not (.isDirectory entry))
                :let [output-file (fs/file target (.getName entry))]]
          (fs/mkdirs (fs/parent output-file))
-         (io/copy tin output-file)))))
+         (io/copy tin output-file)
+         (when (.isFile entry)
+           (fs/chmod (apply str (take-last
+                                 3 (format "%05o" (.getMode entry))))
+                     (.getPath output-file)))))))
 
 (defn gunzip
   "Takes a path to a gzip file `source` and unzips it."

--- a/test/me/raynes/core_test.clj
+++ b/test/me/raynes/core_test.clj
@@ -192,6 +192,20 @@
     (delete f)))
 
 (fact
+  (let [f (temp-file "fs-")]
+    (chmod "777" f)
+    (executable? f) => true
+    (readable? f) => true
+    (writeable? f) => true
+    (chmod "000" f)
+    (when-not (re-find #"Windows" (System/getProperty "os.name"))
+      (chmod "-x" f)
+      (executable? f) => false
+      (readable? f) => false
+      (writeable? f) => false)
+    (delete f)))
+
+(fact
   (let [from (create-walk-dir)
         to (temp-dir "fs-")
         path (copy-dir from to)


### PR DESCRIPTION
Noticed that untar loses file permissions. Had to build support for octal permission format in chmod to fix it.