### PR TITLE
Adds `ephemeral-{file,dir}` fns

### DIFF
--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -344,6 +344,24 @@
   ([prefix suffix]       (temp-dir prefix suffix 10))
   ([prefix suffix tries] (temp-create prefix suffix tries mkdirs)))
 
+(defn ephemeral-file
+  "Create an ephemeral file (will be deleted on JVM exit).
+   Returns nil if file could not be created even after n tries
+  (default 10)."
+  ([prefix]              (ephemeral-file prefix "" 10))
+  ([prefix suffix]       (ephemeral-file prefix suffix 10))
+  ([prefix suffix tries] (when-let [created (temp-create prefix suffix tries create)]
+                           (doto created .deleteOnExit))))
+
+(defn ephemeral-dir
+  "Create an ephemeral directory (will be deleted on JVM exit).
+   Returns nil if dir could not be created even after n tries
+  (default 10)."
+  ([prefix]              (ephemeral-dir prefix "" 10))
+  ([prefix suffix]       (ephemeral-dir prefix suffix 10))
+  ([prefix suffix tries] (when-let [created (temp-create prefix suffix tries mkdirs)]
+                           (doto created .deleteOnExit))))
+
 ; Taken from https://github.com/jkk/clj-glob. (thanks Justin!)
 (defn- glob->regex
   "Takes a glob-format string and returns a regex."

--- a/test/me/raynes/core_test.clj
+++ b/test/me/raynes/core_test.clj
@@ -98,6 +98,16 @@
     (delete tmp)))
 
 (fact
+ (let [tmp (ephemeral-file "fs-")]
+   (exists? tmp) => true
+   (file? tmp) => true)) ;; is deleted on JVM exit
+
+(fact
+ (let [tmp (ephemeral-dir "fs-")]
+   (exists? tmp) => true
+   (directory? tmp) => true)) ;; is deleted on JVM exit
+
+(fact
   (absolute "foo") => (io/file *cwd* "foo"))
 
 (fact


### PR DESCRIPTION
These are the same as temp-{file,dir} but set .deleteOnExit on the created
things so they are removed when the JVM shuts down.

It was not possible to add a :delete-on-exit arg to the existing
temp-{file,dir} fns as they are variadic.
