### PR TITLE
Use tree-seq to make iterate-dir lazy

### DIFF
--- a/src/me/raynes/fs.clj
+++ b/src/me/raynes/fs.clj
@@ -414,9 +414,8 @@
   (.listFiles f))
 
 (defn- iterate-dir* [path]
-  (let [root (file path)
-        nodes (butlast (iterzip (zip/zipper f-dir? f-children nil root)))]
-    (filter f-dir? nodes)))
+  (let [root (file path)]
+    (filter f-dir? (tree-seq f-dir? f-children root))))
 
 (defn- walk-map-fn [root]
   (let [kids (f-children root)
@@ -425,7 +424,7 @@
     [root dirs files]))
 
 (defn iterate-dir
-  "Return a sequence `[root dirs files]`, starting from `path` in depth-first order"
+  "Return a lazy sequence `[root dirs files]`, starting from `path` in depth-first order"
   [path]
   (map walk-map-fn (iterate-dir* path)))
 


### PR DESCRIPTION
The previous implementation of `iterate-dir` was not lazy and would eagerly traverse the entire directory hierarchy and load it all into memory. Because it was eager, the entire directory tree structure would need to be loaded before the `iterate-dir` function returned. When used on very large directory trees, this could be very slow and could also produce a `java.lang.OutOfMemoryError`. (See issue #38)

By using `tree-seq` to lazily traverse the directory tree, the `iterate-dir` function now immediately returns a lazy sequence (even on very large directory trees) because it does not need to first traverse and load the tree. This also means that `iterate-dir` will not itself produce an `OutOfMemoryError` when used on large directory trees. Unfortunately, however, it seems that Clojure's lazy sequence are still susceptible to `OutOfMemoryError`s. Even using the lazy `tree-seq` approach, an `OutOfMemoryError` can be produced when _processing_ very large directory trees (e.g. with `dorun` or `doseq`, or even `count`):

```OutOfMemoryError GC overhead limit exceeded```

Nevertheless, this is still an improvement over the previous implementation since the `OutOfMemoryError` is not produced immediately upon calling `iterate-dir`, but rather only after processing a very large portion of the results. This seems to be a limitation in Clojure itself, in any case.