### PR TITLE
added with-temp-dir macro

### DIFF
--- a/test/me/raynes/core_test.clj
+++ b/test/me/raynes/core_test.clj
@@ -372,6 +372,12 @@
     (absolute? "foo/bar") => false
     (absolute? "foo/") => false))
 
+(fact
+    (let [temp-dirs (with-temp-dir [source target]
+                      (every? directory? [source target]) => true
+                      [source target])]
+      (every? (comp not exists?) temp-dirs)))
+
 (defmacro run-java-7-tests []
   (when (try (import '[java.nio.file Files Path LinkOption StandardCopyOption FileAlreadyExistsException]
                      '[java.nio.file.attribute FileAttribute])


### PR DESCRIPTION
might be useful

```clojure
(me.raynes.fs/with-temp-dir [source target]
  (let [f (str source "/shuki.txt")
        t (str target "/shuki.txt")]
    (spit f "hello")
    (me.raynes.fs/rename f t)
    (slurp t)))
```

all temp folders will be deleted after execution